### PR TITLE
JDK9 doclet & java 8+9 builds (#258)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 dist: trusty
 jdk:
 - oraclejdk8
+- oraclejdk9
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -19,16 +20,18 @@ script:
 - mvn install -B -V
 - cd samples
 - mvn install -B -V
-- cd java-webmvc
-- ./gradlew check
-- cd ..
-- cd kotlin-webmvc
-- ./gradlew check
-- cd ../..
+- test "$TRAVIS_JDK_VERSION" = "oraclejdk8" && cd java-webmvc && ./gradlew check && cd .. || (exit 0)
+- test "$TRAVIS_JDK_VERSION" = "oraclejdk8" && cd kotlin-webmvc && ./gradlew check && cd .. || (exit 0)
 after_success:
 - test "$TRAVIS_BRANCH" = "master"
   && test "$TRAVIS_PULL_REQUEST" = "false"
   && test "$TRAVIS_JDK_VERSION" = "oraclejdk8"
+  && "$DEPLOY_DIR/decrypt.sh"
+  && mvn deploy --settings "$DEPLOY_DIR/travis-settings.xml" -DskipTests=true -B -V
+- test "$TRAVIS_BRANCH" = "master"
+  && test "$TRAVIS_PULL_REQUEST" = "false"
+  && test "$TRAVIS_JDK_VERSION" = "oraclejdk9"
+  && cd spring-auto-restdocs-json-doclet-jdk9
   && "$DEPLOY_DIR/decrypt.sh"
   && mvn deploy --settings "$DEPLOY_DIR/travis-settings.xml" -DskipTests=true -B -V
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,6 @@
     <description>Parent POM for Spring Auto REST Docs</description>
     <url>https://github.com/scacap/spring-auto-restdocs</url>
 
-    <modules>
-        <module>spring-auto-restdocs-json-doclet</module>
-        <module>spring-auto-restdocs-core</module>
-        <module>spring-auto-restdocs-docs</module>
-        <module>spring-auto-restdocs-dokka-json</module>
-    </modules>
-
     <organization>
         <name>Scalable Capital GmbH</name>
         <url>https://scalable.capital</url>
@@ -53,9 +46,6 @@
     </developers>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
         <spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>
@@ -141,7 +131,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -151,7 +141,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -166,7 +156,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.asciidoctor</groupId>
@@ -183,6 +173,41 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet</json-doclet.artifactId>
+            </properties>
+            <modules>
+                <module>spring-auto-restdocs-json-doclet</module>
+                <module>spring-auto-restdocs-dokka-json</module>
+                <module>spring-auto-restdocs-core</module>
+                <module>spring-auto-restdocs-docs</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <java.version>9</java.version>
+                <maven.compiler.source>9</maven.compiler.source>
+                <maven.compiler.target>9</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet-jdk9</json-doclet.artifactId>
+            </properties>
+            <modules>
+                <module>spring-auto-restdocs-json-doclet-jdk9</module>
+                <module>spring-auto-restdocs-core</module>
+                <module>spring-auto-restdocs-docs</module>
+            </modules>
+        </profile>
         <profile>
             <id>sign-artifacts</id>
             <activation>

--- a/samples/java-webmvc/pom.xml
+++ b/samples/java-webmvc/pom.xml
@@ -32,9 +32,6 @@
     </licenses>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>
@@ -59,13 +56,6 @@
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
             <version>2.3.0.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <!-- Lombok 1.16.20+ is required for JDK9 -->
-            <version>1.16.20</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -96,7 +86,54 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet</json-doclet.artifactId>
+            </properties>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <java.version>9</java.version>
+                <maven.compiler.source>9</maven.compiler.source>
+                <maven.compiler.target>9</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet-jdk9</json-doclet.artifactId>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -212,7 +249,7 @@
                             <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
                             <docletArtifact>
                                 <groupId>capital.scalable</groupId>
-                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <artifactId>${json-doclet.artifactId}</artifactId>
                                 <version>${spring-auto-restdocs.version}</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -35,8 +35,6 @@ import capital.scalable.restdocs.example.common.Money;
 import capital.scalable.restdocs.example.constraints.English;
 import capital.scalable.restdocs.example.constraints.German;
 import capital.scalable.restdocs.example.constraints.Id;
-import lombok.Data;
-import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -272,22 +270,43 @@ public class ItemResource {
         private String name;
     }
 
-    @Data
     static class Command {
         /**
          * Command to execute
          */
         @NotBlank
         private String command;
+
+        public Command() {
+        }
+
+        public Command(@NotBlank String command) {
+            this.command = command;
+        }
+
+        public void setCommand(String command) {
+            this.command = command;
+        }
+
+        public String getCommand() {
+            return command;
+        }
     }
 
-    @Value
     static class CommandResult {
         /**
          * Log output
          */
         @NotBlank
         private String output;
+
+        public CommandResult(@NotBlank String output) {
+            this.output = output;
+        }
+
+        public String getOutput() {
+            return output;
+        }
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
@@ -25,12 +25,10 @@ import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
 
 /**
  * Java object for a single JSON item.
  */
-@AllArgsConstructor
 class ItemResponse {
     /**
      * Unique ID. This text comes directly from Javadoc.
@@ -67,6 +65,16 @@ class ItemResponse {
      * Tags.
      */
     private String[] tags;
+
+    ItemResponse(String id, String desc, Metadata meta, Attributes attributes, List<ItemResponse> children,
+            String[] tags) {
+        this.id = id;
+        this.desc = desc;
+        this.meta = meta;
+        this.attributes = attributes;
+        this.children = children;
+        this.tags = tags;
+    }
 
     /**
      * Some information | description about the item.

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
@@ -25,13 +25,11 @@ import javax.validation.constraints.Size;
 import capital.scalable.restdocs.example.constraints.English;
 import capital.scalable.restdocs.example.constraints.German;
 import capital.scalable.restdocs.example.constraints.OneOf;
-import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
 /**
  * Java object for the JSON request.
  */
-@Data
 class ItemUpdateRequest {
     /**
      * Some information about the item.
@@ -53,4 +51,8 @@ class ItemUpdateRequest {
             @OneOf(value = {"small", "big"}, groups = English.class)
     })
     private String type;
+
+    String getDescription() {
+        return description;
+    }
 }

--- a/samples/java-webtestclient/pom.xml
+++ b/samples/java-webtestclient/pom.xml
@@ -32,9 +32,6 @@
     </licenses>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>
@@ -53,12 +50,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -94,14 +90,45 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
             <version>9.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.3</version>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet</json-doclet.artifactId>
+            </properties>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <java.version>9</java.version>
+                <maven.compiler.source>9</maven.compiler.source>
+                <maven.compiler.target>9</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet-jdk9</json-doclet.artifactId>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -217,7 +244,7 @@
                             <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
                             <docletArtifact>
                                 <groupId>capital.scalable</groupId>
-                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <artifactId>${json-doclet.artifactId}</artifactId>
                                 <version>${spring-auto-restdocs.version}</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>

--- a/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/Application.java
+++ b/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/Application.java
@@ -21,7 +21,6 @@ package capital.scalable.restdocs.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 /**
  * Entry point to the application.

--- a/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -35,8 +35,6 @@ import capital.scalable.restdocs.example.common.Money;
 import capital.scalable.restdocs.example.constraints.English;
 import capital.scalable.restdocs.example.constraints.German;
 import capital.scalable.restdocs.example.constraints.Id;
-import lombok.Data;
-import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -270,22 +268,43 @@ public class ItemResource {
         private String name;
     }
 
-    @Data
     static class Command {
         /**
          * Command to execute
          */
         @NotBlank
         private String command;
+
+        public Command() {
+        }
+
+        public Command(@NotBlank String command) {
+            this.command = command;
+        }
+
+        public String getCommand() {
+            return command;
+        }
+
+        public void setCommand(String command) {
+            this.command = command;
+        }
     }
 
-    @Value
     static class CommandResult {
         /**
          * Log output
          */
         @NotBlank
         private String output;
+
+        public CommandResult(String output) {
+            this.output = output;
+        }
+
+        public String getOutput() {
+            return output;
+        }
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
+++ b/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
@@ -25,12 +25,10 @@ import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
 
 /**
  * Java object for a single JSON item.
  */
-@AllArgsConstructor
 class ItemResponse {
     /**
      * Unique ID. This text comes directly from Javadoc.
@@ -46,8 +44,7 @@ class ItemResponse {
      * <p>
      * An example of JsonSubType support.
      *
-     * @see
-     * <a href="https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations#type-handling">
+     * @see <a href="https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations#type-handling">
      * Jackson type documentation</a>
      */
     private Metadata meta;
@@ -74,5 +71,15 @@ class ItemResponse {
      */
     public String getDescription() {
         return desc;
+    }
+
+    public ItemResponse(String id, String desc, Metadata meta, Attributes attributes, List<ItemResponse> children,
+            String[] tags) {
+        this.id = id;
+        this.desc = desc;
+        this.meta = meta;
+        this.attributes = attributes;
+        this.children = children;
+        this.tags = tags;
     }
 }

--- a/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
+++ b/samples/java-webtestclient/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
@@ -25,13 +25,11 @@ import javax.validation.constraints.Size;
 import capital.scalable.restdocs.example.constraints.English;
 import capital.scalable.restdocs.example.constraints.German;
 import capital.scalable.restdocs.example.constraints.OneOf;
-import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
 /**
  * Java object for the JSON request.
  */
-@Data
 class ItemUpdateRequest {
     /**
      * Some information about the item.
@@ -53,4 +51,20 @@ class ItemUpdateRequest {
             @OneOf(value = {"small", "big"}, groups = English.class)
     })
     private String type;
+
+    public ItemUpdateRequest() {
+    }
+
+    public ItemUpdateRequest(String description, String type) {
+        this.description = description;
+        this.type = type;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/samples/java-webtestclient/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
+++ b/samples/java-webtestclient/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
@@ -26,14 +26,12 @@ import static org.springframework.restdocs.webtestclient.WebTestClientRestDocume
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.util.DefaultUriBuilderFactory;
-
 import capital.scalable.restdocs.example.items.ItemResource.Command;
 import capital.scalable.restdocs.example.items.ItemResource.CommandResult;
 import capital.scalable.restdocs.example.testsupport.WebTestClientTestBase;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 
 public class ItemResourceTest extends WebTestClientTestBase {
@@ -71,11 +69,11 @@ public class ItemResourceTest extends WebTestClientTestBase {
 				.consumeWith(commonDocumentation());
     }
 
-    @Test
-    public void addItem() {
+	@Test
+	public void addItem() {
 		ItemUpdateRequest data = new ItemUpdateRequest();
 		data.setDescription("Hot News");
-        webTestClient.mutate().filter(userToken()).build().post().uri("/items")
+		webTestClient.post().uri("/items")
                 .contentType(MediaType.APPLICATION_JSON)
 				.body(Mono.just(data), ItemUpdateRequest.class)
 				.exchange()
@@ -83,26 +81,26 @@ public class ItemResourceTest extends WebTestClientTestBase {
 				.expectHeader().valueEquals("location","http://localhost:8080/items/2")
 				.expectBody()
 				.consumeWith(commonDocumentation());
-    }
+	}
 
-    @Test
-    public void updateItem() {
+	@Test
+	public void updateItem() {
 		ItemUpdateRequest data = new ItemUpdateRequest();
 		data.setDescription("Hot News");
-        webTestClient.mutate().filter(userToken()).build().put().uri("/items/1")
-                .contentType(MediaType.APPLICATION_JSON)
+		webTestClient.put().uri("/items/1")
+				.contentType(MediaType.APPLICATION_JSON)
 				.body(Mono.just(data), ItemUpdateRequest.class)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody()
 				.jsonPath("$.id").isEqualTo("1")
-                .jsonPath("$.description"). isEqualTo("Hot News")
+				.jsonPath("$.description"). isEqualTo("Hot News")
 				.consumeWith(commonDocumentation());
-    }
+	}
 
     @Test
     public void deleteItem() {
-        webTestClient.mutate().filter(userToken()).build().delete().uri("/items/{id}", 1)
+		webTestClient.delete().uri("/items/{id}", 1)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody()

--- a/samples/java-webtestclient/src/test/java/capital/scalable/restdocs/example/testsupport/WebTestClientTestBase.java
+++ b/samples/java-webtestclient/src/test/java/capital/scalable/restdocs/example/testsupport/WebTestClientTestBase.java
@@ -19,19 +19,30 @@
  */
 package capital.scalable.restdocs.example.testsupport;
 
-import static capital.scalable.restdocs.AutoDocumentation.*;
+import static capital.scalable.restdocs.AutoDocumentation.authorization;
+import static capital.scalable.restdocs.AutoDocumentation.description;
+import static capital.scalable.restdocs.AutoDocumentation.methodAndPath;
+import static capital.scalable.restdocs.AutoDocumentation.pathParameters;
+import static capital.scalable.restdocs.AutoDocumentation.requestFields;
+import static capital.scalable.restdocs.AutoDocumentation.requestParameters;
+import static capital.scalable.restdocs.AutoDocumentation.responseFields;
+import static capital.scalable.restdocs.AutoDocumentation.section;
 import static capital.scalable.restdocs.response.ResponseModifyingPreprocessors.limitJsonArrayLength;
 import static capital.scalable.restdocs.response.ResponseModifyingPreprocessors.replaceBinaryContent;
 import static org.springframework.restdocs.cli.CliDocumentation.curlRequest;
 import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
 import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
 import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
 
 import java.util.function.Consumer;
 
+import capital.scalable.restdocs.webtestclient.WebTestClientInitializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -48,10 +59,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.Base64Utils;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.util.DefaultUriBuilderFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import capital.scalable.restdocs.webtestclient.WebTestClientInitializer;
 
 /**
  * Required set up code for WebTestClient tests.

--- a/samples/kotlin-webmvc/pom.xml
+++ b/samples/kotlin-webmvc/pom.xml
@@ -32,7 +32,6 @@
     </licenses>
 
     <properties>
-        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-restdocs.version>2.0.2.RELEASE</spring-restdocs.version>
         <spring-auto-restdocs.version>2.0.2-SNAPSHOT</spring-auto-restdocs.version>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -29,6 +29,18 @@
         <module>shared</module>
         <module>java-webmvc</module>
         <module>java-webtestclient</module>
-        <module>kotlin-webmvc</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>kotlin-webmvc</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>

--- a/samples/shared/pom.xml
+++ b/samples/shared/pom.xml
@@ -32,9 +32,6 @@
     </licenses>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-auto-restdocs.version>2.0.2-SNAPSHOT</spring-auto-restdocs.version>
     </properties>
@@ -46,17 +43,37 @@
             <version>2.9.5</version>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <!-- Lombok 1.16.20+ is required for JDK9 -->
-            <version>1.16.20</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet</json-doclet.artifactId>
+            </properties>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <java.version>9</java.version>
+                <maven.compiler.source>9</maven.compiler.source>
+                <maven.compiler.target>9</maven.compiler.target>
+                <json-doclet.artifactId>spring-auto-restdocs-json-doclet-jdk9</json-doclet.artifactId>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -72,7 +89,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -91,7 +110,7 @@
                             <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
                             <docletArtifact>
                                 <groupId>capital.scalable</groupId>
-                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <artifactId>${json-doclet.artifactId}</artifactId>
                                 <version>${spring-auto-restdocs.version}</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>

--- a/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Attributes.java
+++ b/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Attributes.java
@@ -29,12 +29,10 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
 import capital.scalable.restdocs.example.common.Money;
-import lombok.Value;
 
 /**
  * Various attributes about the item.
  */
-@Value
 public class Attributes {
     /**
      * Textual attribute.
@@ -69,4 +67,13 @@ public class Attributes {
      */
     @NotNull
     private EnumType enumType;
+
+    Attributes(String text, Integer number, Boolean bool, BigDecimal decimal, Money amount, EnumType enumType) {
+        this.text = text;
+        this.number = number;
+        this.bool = bool;
+        this.decimal = decimal;
+        this.amount = amount;
+        this.enumType = enumType;
+    }
 }

--- a/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Metadata.java
+++ b/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Metadata.java
@@ -26,11 +26,7 @@ import javax.validation.constraints.NotBlank;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonTypeInfo(use = NAME, include = PROPERTY, property = "type", visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = Metadata1.class, name = "1"),
@@ -42,6 +38,13 @@ public class Metadata {
      */
     @NotBlank
     private String type;
+
+    Metadata() {
+    }
+
+    Metadata(@NotBlank String type) {
+        this.type = type;
+    }
 }
 
 

--- a/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Metadata1.java
+++ b/samples/shared/src/main/java/capital/scalable/restdocs/example/items/Metadata1.java
@@ -20,14 +20,14 @@
 
 package capital.scalable.restdocs.example.items;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public class Metadata1 extends Metadata {
     /**
      * Tag attribute. Available only if metadata type=1
      */
     private String tag;
+
+    Metadata1() {
+    }
 
     public Metadata1(String type, String tag) {
         super(type);

--- a/spring-auto-restdocs-core/pom.xml
+++ b/spring-auto-restdocs-core/pom.xml
@@ -122,7 +122,7 @@
                             <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
                             <docletArtifact>
                                 <groupId>capital.scalable</groupId>
-                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <artifactId>${json-doclet.artifactId}</artifactId>
                                 <version>${project.parent.version}</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>

--- a/spring-auto-restdocs-json-doclet-jdk9/pom.xml
+++ b/spring-auto-restdocs-json-doclet-jdk9/pom.xml
@@ -9,10 +9,11 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+    <artifactId>spring-auto-restdocs-json-doclet-jdk9</artifactId>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Spring Auto REST Docs Json Doclet</name>
+    <name>Spring Auto REST Docs Json Doclet for JDK9+</name>
     <description>Doclet exporting JavaDoc to JSON for Spring Auto REST Docs</description>
 
     <properties>
@@ -20,14 +21,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.4.2</version>
-            <scope>system</scope>
-            <optional>true</optional>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -58,6 +51,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>9</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <extensions>true</extensions>
                 <executions>
@@ -71,7 +70,7 @@
                             <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
                             <docletArtifact>
                                 <groupId>capital.scalable</groupId>
-                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <artifactId>spring-auto-restdocs-json-doclet-jdk9</artifactId>
                                 <version>${project.parent.version}</version>
                             </docletArtifact>
                             <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
@@ -1,0 +1,70 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupDocComment;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import java.util.HashMap;
+import java.util.Map;
+
+import jdk.javadoc.doclet.DocletEnvironment;
+
+public final class ClassDocumentation {
+    private String comment = "";
+    private final Map<String, FieldDocumentation> fields = new HashMap<>();
+    private final Map<String, MethodDocumentation> methods = new HashMap<>();
+
+    private ClassDocumentation() {
+        // enforce usage of static factory method
+    }
+
+    public static ClassDocumentation fromClassDoc(DocletEnvironment docEnv,
+            Element element) {
+        ClassDocumentation cd = new ClassDocumentation();
+        cd.setComment(cleanupDocComment(docEnv.getElementUtils().getDocComment(element)));
+
+        element.getEnclosedElements().forEach(fieldOrMethod -> {
+            if (fieldOrMethod.getKind().equals(ElementKind.FIELD)) {
+                cd.addField(docEnv, fieldOrMethod);
+            } else if (fieldOrMethod.getKind().equals(ElementKind.METHOD)
+                    || fieldOrMethod.getKind().equals(ElementKind.CONSTRUCTOR)) {
+                cd.addMethod(docEnv, fieldOrMethod);
+            }
+        });
+
+        return cd;
+    }
+
+    private void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    private void addField(DocletEnvironment docEnv, Element element) {
+        this.fields.put(element.getSimpleName().toString(),
+                FieldDocumentation.fromFieldDoc(docEnv, element));
+    }
+
+    private void addMethod(DocletEnvironment docEnv, Element element) {
+        this.methods.put(element.getSimpleName().toString(),
+                MethodDocumentation.fromMethodDoc(docEnv, element));
+    }
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/DocletAbortException.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/DocletAbortException.java
@@ -1,15 +1,15 @@
 /*-
  * #%L
- * Spring Auto REST Docs Shared POJOs Example Project
+ * Spring Auto REST Docs Json Doclet for JDK9+
  * %%
  * Copyright (C) 2015 - 2018 Scalable Capital GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,20 +17,11 @@
  * limitations under the License.
  * #L%
  */
+package capital.scalable.restdocs.jsondoclet;
 
-package capital.scalable.restdocs.example.items;
+class DocletAbortException extends RuntimeException {
 
-public class Metadata2 extends Metadata {
-    /**
-     * Order attribute. Available only if metadata type=2
-     */
-    private Integer order;
-
-    Metadata2() {
-    }
-
-    public Metadata2(String type, Integer order) {
-        super(type);
-        this.order = order;
+    public DocletAbortException(String message) {
+        super(message);
     }
 }

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
@@ -1,15 +1,15 @@
 /*-
  * #%L
- * Spring Auto REST Docs Shared POJOs Example Project
+ * Spring Auto REST Docs Json Doclet for JDK9+
  * %%
  * Copyright (C) 2015 - 2018 Scalable Capital GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,20 +17,25 @@
  * limitations under the License.
  * #L%
  */
+package capital.scalable.restdocs.jsondoclet;
 
-package capital.scalable.restdocs.example.items;
+import java.util.Optional;
 
-public class Metadata2 extends Metadata {
-    /**
-     * Order attribute. Available only if metadata type=2
-     */
-    private Integer order;
-
-    Metadata2() {
+public class DocletUtils {
+    private DocletUtils() {
+        // utils
     }
 
-    public Metadata2(String type, Integer order) {
-        super(type);
-        this.order = order;
+    static String cleanupDocComment(String comment) {
+        return Optional.ofNullable(comment).map(s -> s.replaceAll("[\\r\\n]+\\s*@.*", "").trim()).orElse("");
     }
+
+    public static String cleanupTagValue(String value) {
+        return value.replaceFirst("\\s*@[^\\s]+\\s+", "").trim();
+    }
+
+    public static String cleanupTagName(String name) {
+        return name.startsWith("@") ? name.substring(1) : name;
+    }
+
 }

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDoclet.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDoclet.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jdk.javadoc.doclet.DocletEnvironment;
+import jdk.javadoc.doclet.StandardDoclet;
+
+/**
+ * Javadoc to JSON doclet.
+ */
+public class ExtractDocumentationAsJsonDoclet extends StandardDoclet {
+
+    @Override
+    public boolean run(DocletEnvironment docEnv) {
+
+        Path destinationDir = Paths.get("../generated-javadoc-json").toAbsolutePath();
+        ObjectMapper mapper = createObjectMapper();
+
+        docEnv.getIncludedElements()
+                .stream().parallel()
+                .filter(e -> e.getKind().isClass() || e.getKind().isInterface())
+                .forEach(classOrInterface -> writeToFile(
+                        destinationDir,
+                        mapper,
+                        findPackageElement(classOrInterface),
+                        (TypeElement) classOrInterface,
+                        ClassDocumentation.fromClassDoc(docEnv, classOrInterface)
+                ));
+
+        return true;
+    }
+
+    private static PackageElement findPackageElement(Element classOrInterface) {
+        Element pkg = classOrInterface.getEnclosingElement();
+        int i = 10;
+        while (!ElementKind.PACKAGE.equals(pkg.getKind())) {
+            if (i-- > 0) {
+                pkg = pkg.getEnclosingElement();
+            } else {
+                throw new DocletAbortException("Class or interface " + classOrInterface + "to deeply nested!");
+            }
+        }
+        return (PackageElement) pkg;
+    }
+
+    private static void writeToFile(Path destinationDir, ObjectMapper mapper,
+            PackageElement packageElement, TypeElement classOrInterface,
+            ClassDocumentation cd) {
+        try {
+            Path path = path(destinationDir, packageElement, classOrInterface);
+            try (BufferedWriter writer = Files.newBufferedWriter(path, UTF_8)) {
+                mapper.writerFor(ClassDocumentation.class).writeValue(writer, cd);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new DocletAbortException("Error writing file: " + e);
+        }
+    }
+
+    private static Path path(Path destinationDir, PackageElement packageElement,
+            TypeElement classOrInterface) throws IOException {
+        String packageName = packageElement.getQualifiedName().toString();
+        String packageDir = packageName.replace(".", File.separator);
+        Path packagePath = Paths.get(packageDir);
+
+        final Path path;
+        if (destinationDir != null) {
+            path = destinationDir.resolve(packageDir);
+        } else {
+            path = packagePath;
+        }
+
+        Files.createDirectories(path);
+
+        String filename = classOrInterface.getQualifiedName().toString()
+                .replace(packageElement.getQualifiedName() + ".", "");
+        return path.resolve(filename + ".json");
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+        return mapper;
+    }
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupDocComment;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagName;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagValue;
+
+import javax.lang.model.element.Element;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.sun.source.doctree.BlockTagTree;
+import jdk.javadoc.doclet.DocletEnvironment;
+
+public class FieldDocumentation {
+
+    private String comment;
+    private final Map<String, String> tags = new HashMap<>();
+
+    public static FieldDocumentation fromFieldDoc(DocletEnvironment docEnv,
+            Element fieldElement) {
+        FieldDocumentation fd = new FieldDocumentation();
+        fd.comment = cleanupDocComment(docEnv.getElementUtils().getDocComment(fieldElement));
+
+
+        Optional.ofNullable(docEnv.getDocTrees().getDocCommentTree(fieldElement))
+                .ifPresent(docCommentTree -> docCommentTree.getBlockTags()
+                        .forEach(tag -> fd.tags.put(
+                                cleanupTagName(((BlockTagTree) tag).getTagName()),
+                                cleanupTagValue(tag.toString()))));
+
+        return fd;
+    }
+
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/MethodDocumentation.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/main/java/capital/scalable/restdocs/jsondoclet/MethodDocumentation.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupDocComment;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagName;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagValue;
+
+import javax.lang.model.element.Element;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.sun.source.doctree.BlockTagTree;
+import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.ParamTree;
+import jdk.javadoc.doclet.DocletEnvironment;
+
+public class MethodDocumentation {
+    private String comment = "";
+    private final Map<String, String> parameters = new HashMap<>();
+    private final Map<String, String> tags = new HashMap<>();
+
+    private MethodDocumentation() {
+        // enforce usage of static factory method
+    }
+
+    public static MethodDocumentation fromMethodDoc(DocletEnvironment docEnv,
+            Element methodElement) {
+        MethodDocumentation md = new MethodDocumentation();
+        md.comment = cleanupDocComment(docEnv.getElementUtils().getDocComment(methodElement));
+
+        Optional.ofNullable(docEnv.getDocTrees().getDocCommentTree(methodElement))
+                .ifPresent(docCommentTree -> docCommentTree.getBlockTags().forEach(tag -> {
+                    if (tag.getKind().equals(DocTree.Kind.PARAM)) {
+                        ParamTree paramTag = (ParamTree) tag;
+                        md.parameters.put(paramTag.getName().toString(),
+                                paramTag.getDescription().toString());
+                    } else {
+                        md.tags.put(
+                                cleanupTagName(((BlockTagTree) tag).getTagName()),
+                                cleanupTagValue(tag.toString()));
+                    }
+                }));
+
+        return md;
+    }
+
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/test/java/capital/scalable/restdocs/jsondoclet/DocumentedClass.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/test/java/capital/scalable/restdocs/jsondoclet/DocumentedClass.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import java.math.BigDecimal;
+
+/**
+ * This is a test class. UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép
+ */
+class DocumentedClass {
+    /**
+     * Location of resource
+     *
+     * @see path
+     */
+    public String location;
+
+    /**
+     * Path within location
+     */
+    private BigDecimal path;
+
+    Boolean notDocumented;
+
+    /**
+     * Executes request on specified location
+     *
+     * @title Execute request
+     */
+    public void execute() {
+    }
+
+    /**
+     * Initiates request
+     *
+     * @param when  when to initiate
+     * @param force true if force
+     * @title Do initiate
+     * @deprecated use other method
+     */
+    private void initiate(String when, boolean force, int notDocumented) {
+    }
+
+    void notDocumented() {
+    }
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/test/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDocletTest.java
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/test/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDocletTest.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Json Doclet for JDK9+
+ * %%
+ * Copyright (C) 2015 - 2018 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.jsondoclet;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class ExtractDocumentationAsJsonDocletTest {
+
+    private static final String JSON_PATH =
+            "capital/scalable/restdocs/jsondoclet/DocumentedClass.json";
+
+    /**
+     * The test requires that the Doclet is executed before. This is ensured by
+     * the Maven configuration, but not when the test is executed on its own.
+     */
+    @Test
+    public void testDocumentedClass() throws IOException, JSONException {
+        String generated = IOUtils.toString(
+                new FileInputStream(new File("target/generated-javadoc-json/" + JSON_PATH)), UTF_8);
+        String expected = IOUtils.toString(
+                this.getClass().getClassLoader().getResourceAsStream(JSON_PATH), UTF_8);
+        JSONAssert.assertEquals(expected, generated, false);
+    }
+}

--- a/spring-auto-restdocs-json-doclet-jdk9/src/test/resources/capital/scalable/restdocs/jsondoclet/DocumentedClass.json
+++ b/spring-auto-restdocs-json-doclet-jdk9/src/test/resources/capital/scalable/restdocs/jsondoclet/DocumentedClass.json
@@ -1,0 +1,44 @@
+{
+  "comment": "This is a test class. UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép",
+  "fields": {
+    "path": {
+      "comment": "Path within location",
+      "tags": {}
+    },
+    "location": {
+      "comment": "Location of resource",
+      "tags": {
+        "see": "path"
+      }
+    },
+    "notDocumented": {
+      "comment": "",
+      "tags": {}
+    }
+  },
+  "methods": {
+    "initiate": {
+      "comment": "Initiates request",
+      "parameters": {
+        "force": "true if force",
+        "when": "when to initiate"
+      },
+      "tags": {
+        "deprecated": "use other method",
+        "title": "Do initiate"
+      }
+    },
+    "execute": {
+      "comment": "Executes request on specified location",
+      "parameters": {},
+      "tags": {
+        "title": "Execute request"
+      }
+    },
+    "notDocumented": {
+      "comment": "",
+      "parameters": {},
+      "tags": {}
+    }
+  }
+}


### PR DESCRIPTION
Fixes #243
Closes #251 

- entire project and samples are built on both configs (kotlin sample only java 8) 
- added JDK9 doclet from #251 as a new module
- doclet versions are built and deployed during respective java version build.
- removed lombok